### PR TITLE
Fix compiling of versioned fields

### DIFF
--- a/font-codegen/src/table.rs
+++ b/font-codegen/src/table.rs
@@ -236,14 +236,10 @@ fn generate_debug(item: &Table) -> syn::Result<TokenStream> {
     let generic_bounds = generic
         .is_some()
         .then(|| quote!(: FontRead<'a> + SomeTable<'a> + 'a));
-    let version = item
-        .fields
-        .iter()
-        .find(|fld| fld.attrs.version.is_some())
-        .map(|fld| {
-            let name = &fld.name;
-            quote!(let version = self.#name();)
-        });
+    let version = item.fields.version_field().map(|fld| {
+        let name = &fld.name;
+        quote!(let version = self.#name();)
+    });
     let field_arms = item.fields.iter_field_traversal_match_arms(false);
     let attrs = item.fields.fields.is_empty().then(|| {
         quote! {

--- a/write-fonts/generated/generated_gdef.rs
+++ b/write-fonts/generated/generated_gdef.rs
@@ -31,13 +31,18 @@ pub struct Gdef {
 impl FontWrite for Gdef {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
-        (self.compute_version() as MajorMinor).write_into(writer);
+        let version = self.compute_version() as MajorMinor;
+        version.write_into(writer);
         self.glyph_class_def_offset.write_into(writer);
         self.attach_list_offset.write_into(writer);
         self.lig_caret_list_offset.write_into(writer);
         self.mark_attach_class_def_offset.write_into(writer);
-        self.mark_glyph_sets_def_offset.write_into(writer);
-        self.item_var_store_offset.write_into(writer);
+        version
+            .compatible(MajorMinor::VERSION_1_2)
+            .then(|| self.mark_glyph_sets_def_offset.write_into(writer));
+        version
+            .compatible(MajorMinor::VERSION_1_3)
+            .then(|| self.item_var_store_offset.write_into(writer));
     }
 }
 

--- a/write-fonts/generated/generated_gpos.rs
+++ b/write-fonts/generated/generated_gpos.rs
@@ -21,11 +21,14 @@ pub struct Gpos {
 impl FontWrite for Gpos {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
-        (self.compute_version() as MajorMinor).write_into(writer);
+        let version = self.compute_version() as MajorMinor;
+        version.write_into(writer);
         self.script_list_offset.write_into(writer);
         self.feature_list_offset.write_into(writer);
         self.lookup_list_offset.write_into(writer);
-        self.feature_variations_offset.write_into(writer);
+        version
+            .compatible(MajorMinor::VERSION_1_1)
+            .then(|| self.feature_variations_offset.write_into(writer));
     }
 }
 

--- a/write-fonts/generated/generated_gsub.rs
+++ b/write-fonts/generated/generated_gsub.rs
@@ -22,11 +22,14 @@ pub struct Gsub {
 impl FontWrite for Gsub {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
-        (self.compute_version() as MajorMinor).write_into(writer);
+        let version = self.compute_version() as MajorMinor;
+        version.write_into(writer);
         self.script_list_offset.write_into(writer);
         self.feature_list_offset.write_into(writer);
         self.lookup_list_offset.write_into(writer);
-        self.feature_variations_offset.write_into(writer);
+        version
+            .compatible(MajorMinor::VERSION_1_1)
+            .then(|| self.feature_variations_offset.write_into(writer));
     }
 }
 

--- a/write-fonts/src/layout/gdef.rs
+++ b/write-fonts/src/layout/gdef.rs
@@ -19,3 +19,37 @@ impl Gdef {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn var_store_without_glyph_sets() {
+        // this should compile, and version should be 1.3
+        let gdef = Gdef {
+            glyph_class_def_offset: NullableOffsetMarker::new(None),
+            attach_list_offset: NullableOffsetMarker::new(None),
+            lig_caret_list_offset: NullableOffsetMarker::new(None),
+            mark_attach_class_def_offset: NullableOffsetMarker::new(None),
+            mark_glyph_sets_def_offset: NullableOffsetMarker::new(None),
+            item_var_store_offset: NullableOffsetMarker::new(Some(ClassDef::Format1(
+                crate::layout::ClassDefFormat1 {
+                    start_glyph_id: GlyphId::new(2),
+                    class_value_array: vec![1, 2, 0],
+                },
+            ))),
+        };
+
+        assert_eq!(gdef.compute_version(), MajorMinor::VERSION_1_3);
+        let _dumped = crate::write::dump_table(&gdef).unwrap();
+        #[cfg(feature = "parsing")]
+        {
+            let data = FontData::new(&_dumped);
+            let loaded = read_fonts::tables::gdef::Gdef::read(data).unwrap();
+
+            assert_eq!(loaded.version(), MajorMinor::VERSION_1_3);
+            assert!(!loaded.item_var_store_offset().unwrap().is_null());
+        }
+    }
+}


### PR DESCRIPTION
A few tweaks to how we handle versioned fields during compilation:

- we now check the version before writing out versioned fields (was a bug)
- during our validation pass, if a table has a version we fetch it, and then check that any fields that are expected to be present for that version are actually present.
- we can now write out versioned scalars (was a bug)