### PR TITLE
[font-types] Reexport InvalidTag at crate root

### DIFF
--- a/font-types/src/lib.rs
+++ b/font-types/src/lib.rs
@@ -29,7 +29,7 @@ pub use glyph_id::GlyphId;
 pub use longdatetime::LongDateTime;
 pub use offset::{Nullable, Offset16, Offset24, Offset32};
 pub use raw::{BigEndian, FixedSized, ReadScalar, Scalar};
-pub use tag::Tag;
+pub use tag::{InvalidTag, Tag};
 pub use uint24::Uint24;
 pub use version::{Compatible, MajorMinor, Version16Dot16};
 


### PR DESCRIPTION
I need this for ttx-rs. =)