### PR TITLE
Prepare to publish initial versions

### DIFF
--- a/font-types/Cargo.toml
+++ b/font-types/Cargo.toml
@@ -1,10 +1,12 @@
 [package]
 name = "font-types"
-version = "0.1.0"
+version = "0.0.1"
 edition = "2021"
 license = "MIT/Apache-2.0"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+description = "Scalar types used in fonts."
+repository = "https://github.com/cmyr/fontations"
+readme = "README.md"
+categories = ["text-processing"]
 
 [features]
 std = []

--- a/font-types/README.md
+++ b/font-types/README.md
@@ -1,0 +1,11 @@
+# font-types
+
+This crate contains definitions of the basic types in the [OpenType
+spec][opentype], as well as informal but useful types (such as a distinct type
+for a glyph ID) and traits for encoding and decoding these types as big-endian
+bytes.
+
+These types are intended to be general purpose, and useable by other Rust
+projects that work with font data.
+
+[opentype]: https://docs.microsoft.com/en-us/typography/opentype/

--- a/read-fonts/Cargo.toml
+++ b/read-fonts/Cargo.toml
@@ -1,16 +1,19 @@
 [package]
 name = "read-fonts"
-version = "0.0.0"
+version = "0.0.1"
 edition = "2021"
 license = "MIT/Apache-2.0"
+description = "Reading OpenType font files."
+repository = "https://github.com/cmyr/fontations"
+readme = "README.md"
+categories = ["text-processing", "parsing", "graphics"]
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
-std = []
+std = ["font-types/std"]
 test_data = []
 traversal = ["std"]
 default = ["traversal"]
 
 [dependencies]
-font-types = { path = "../font-types" }
+font-types = { version = "0.0.1", path = "../font-types" }
 bitflags = "1.3"

--- a/write-fonts/Cargo.toml
+++ b/write-fonts/Cargo.toml
@@ -1,20 +1,23 @@
 [package]
 name = "write-fonts"
-version = "0.0.0"
+version = "0.0.1"
 edition = "2021"
 license = "MIT/Apache-2.0"
-
+description = "Writing font files."
+repository = "https://github.com/cmyr/fontations"
+readme = "README.md"
+categories = ["text-processing", "parsing", "graphics"]
 
 [features]
 parsing = ["read-fonts"]
 default = ["parsing"]
 
 [dependencies]
-font-types = { path = "../font-types" }
-read-fonts = { path = "../read-fonts", optional = true }
+font-types = { version = "0.0.1", path = "../font-types" }
+read-fonts = { version = "0.0.1", path = "../read-fonts", optional = true }
 bitflags = "1.3"
 
 [dev-dependencies]
 diff = "0.1.12"
 ansi_term = "0.12.1"
-read-fonts = { path = "../read-fonts", features = ["test_data"]}
+read-fonts = { version = "0.0.1", path = "../read-fonts", features = ["test_data"] }

--- a/write-fonts/README.md
+++ b/write-fonts/README.md
@@ -1,0 +1,3 @@
+# write-fonts
+
+This crate contains types for creating and editing font-files.


### PR DESCRIPTION
I'd like to get this up on crates.io so that I can start importing it more sanely elsewhere.

This gets us ready for an initial release there, setting version numbers and adding readmes and missing cargo manifest fields.