### PR TITLE
[codegen] Pluralize getter names for arrays of offsets

### DIFF
--- a/font-codegen/src/fields.rs
+++ b/font-codegen/src/fields.rs
@@ -709,10 +709,23 @@ impl Field {
         }
 
         let name_string = self.name.to_string();
-        let offset_name = name_string
-            .trim_end_matches("_offsets")
-            .trim_end_matches("_offset");
-        Some(syn::Ident::new(offset_name, self.name.span()))
+        if name_string.ends_with('s') {
+            // if this is an array of offsets (is pluralized) we also pluralize the getter name
+            let temp = name_string.trim_end_matches("_offsets");
+            // hacky attempt to respect pluralization rules. we can update this
+            // as we encounter actual tables, instead of trying to be systematic
+            let plural_es = temp.ends_with("attach");
+            let suffix = if plural_es { "es" } else { "s" };
+            Some(syn::Ident::new(
+                &format!("{temp}{suffix}"),
+                self.name.span(),
+            ))
+        } else {
+            Some(syn::Ident::new(
+                name_string.trim_end_matches("_offset"),
+                self.name.span(),
+            ))
+        }
     }
 
     /// if the `#[offset_data_method]` attribute is specified, self.#method(),

--- a/read-fonts/generated/generated_gdef.rs
+++ b/read-fonts/generated/generated_gdef.rs
@@ -326,7 +326,7 @@ impl<'a> AttachList<'a> {
     }
 
     /// Attempt to resolve [`attach_point_offsets`][Self::attach_point_offsets].
-    pub fn attach_point(&self) -> impl Iterator<Item = Result<AttachPoint<'a>, ReadError>> + 'a {
+    pub fn attach_points(&self) -> impl Iterator<Item = Result<AttachPoint<'a>, ReadError>> + 'a {
         let data = self.data;
         self.attach_point_offsets()
             .iter()
@@ -507,7 +507,7 @@ impl<'a> LigCaretList<'a> {
     }
 
     /// Attempt to resolve [`lig_glyph_offsets`][Self::lig_glyph_offsets].
-    pub fn lig_glyph(&self) -> impl Iterator<Item = Result<LigGlyph<'a>, ReadError>> + 'a {
+    pub fn lig_glyphs(&self) -> impl Iterator<Item = Result<LigGlyph<'a>, ReadError>> + 'a {
         let data = self.data;
         self.lig_glyph_offsets()
             .iter()
@@ -602,7 +602,7 @@ impl<'a> LigGlyph<'a> {
     }
 
     /// Attempt to resolve [`caret_value_offsets`][Self::caret_value_offsets].
-    pub fn caret_value(&self) -> impl Iterator<Item = Result<CaretValue<'a>, ReadError>> + 'a {
+    pub fn caret_values(&self) -> impl Iterator<Item = Result<CaretValue<'a>, ReadError>> + 'a {
         let data = self.data;
         self.caret_value_offsets()
             .iter()
@@ -982,7 +982,7 @@ impl<'a> MarkGlyphSets<'a> {
     }
 
     /// Attempt to resolve [`coverage_offsets`][Self::coverage_offsets].
-    pub fn coverage(&self) -> impl Iterator<Item = Result<CoverageTable<'a>, ReadError>> + 'a {
+    pub fn coverages(&self) -> impl Iterator<Item = Result<CoverageTable<'a>, ReadError>> + 'a {
         let data = self.data;
         self.coverage_offsets()
             .iter()

--- a/read-fonts/generated/generated_gpos.rs
+++ b/read-fonts/generated/generated_gpos.rs
@@ -1134,7 +1134,7 @@ impl<'a> PairPosFormat1<'a> {
     }
 
     /// Attempt to resolve [`pair_set_offsets`][Self::pair_set_offsets].
-    pub fn pair_set(&self) -> impl Iterator<Item = Result<PairSet<'a>, ReadError>> + 'a {
+    pub fn pair_sets(&self) -> impl Iterator<Item = Result<PairSet<'a>, ReadError>> + 'a {
         let data = self.data;
         let args = (self.value_format1(), self.value_format2());
         self.pair_set_offsets()
@@ -2146,7 +2146,7 @@ impl<'a> BaseRecord<'a> {
     }
 
     /// Attempt to resolve [`base_anchor_offsets`][Self::base_anchor_offsets].
-    pub fn base_anchor(
+    pub fn base_anchors(
         &self,
         data: FontData<'a>,
     ) -> impl Iterator<Item = Option<Result<AnchorTable<'a>, ReadError>>> + 'a {
@@ -2420,7 +2420,7 @@ impl<'a> LigatureArray<'a> {
     }
 
     /// Attempt to resolve [`ligature_attach_offsets`][Self::ligature_attach_offsets].
-    pub fn ligature_attach(
+    pub fn ligature_attaches(
         &self,
     ) -> impl Iterator<Item = Result<LigatureAttach<'a>, ReadError>> + 'a {
         let data = self.data;
@@ -2581,7 +2581,7 @@ impl<'a> ComponentRecord<'a> {
     }
 
     /// Attempt to resolve [`ligature_anchor_offsets`][Self::ligature_anchor_offsets].
-    pub fn ligature_anchor(
+    pub fn ligature_anchors(
         &self,
         data: FontData<'a>,
     ) -> impl Iterator<Item = Option<Result<AnchorTable<'a>, ReadError>>> + 'a {
@@ -2906,7 +2906,7 @@ impl<'a> Mark2Record<'a> {
     }
 
     /// Attempt to resolve [`mark2_anchor_offsets`][Self::mark2_anchor_offsets].
-    pub fn mark2_anchor(
+    pub fn mark2_anchors(
         &self,
         data: FontData<'a>,
     ) -> impl Iterator<Item = Option<Result<AnchorTable<'a>, ReadError>>> + 'a {

--- a/read-fonts/generated/generated_gsub.rs
+++ b/read-fonts/generated/generated_gsub.rs
@@ -535,7 +535,7 @@ impl<'a> MultipleSubstFormat1<'a> {
     }
 
     /// Attempt to resolve [`sequence_offsets`][Self::sequence_offsets].
-    pub fn sequence(&self) -> impl Iterator<Item = Result<Sequence<'a>, ReadError>> + 'a {
+    pub fn sequences(&self) -> impl Iterator<Item = Result<Sequence<'a>, ReadError>> + 'a {
         let data = self.data;
         self.sequence_offsets()
             .iter()
@@ -737,7 +737,7 @@ impl<'a> AlternateSubstFormat1<'a> {
     }
 
     /// Attempt to resolve [`alternate_set_offsets`][Self::alternate_set_offsets].
-    pub fn alternate_set(&self) -> impl Iterator<Item = Result<AlternateSet<'a>, ReadError>> + 'a {
+    pub fn alternate_sets(&self) -> impl Iterator<Item = Result<AlternateSet<'a>, ReadError>> + 'a {
         let data = self.data;
         self.alternate_set_offsets()
             .iter()
@@ -941,7 +941,7 @@ impl<'a> LigatureSubstFormat1<'a> {
     }
 
     /// Attempt to resolve [`ligature_set_offsets`][Self::ligature_set_offsets].
-    pub fn ligature_set(&self) -> impl Iterator<Item = Result<LigatureSet<'a>, ReadError>> + 'a {
+    pub fn ligature_sets(&self) -> impl Iterator<Item = Result<LigatureSet<'a>, ReadError>> + 'a {
         let data = self.data;
         self.ligature_set_offsets()
             .iter()
@@ -1037,7 +1037,7 @@ impl<'a> LigatureSet<'a> {
     }
 
     /// Attempt to resolve [`ligature_offsets`][Self::ligature_offsets].
-    pub fn ligature(&self) -> impl Iterator<Item = Result<Ligature<'a>, ReadError>> + 'a {
+    pub fn ligatures(&self) -> impl Iterator<Item = Result<Ligature<'a>, ReadError>> + 'a {
         let data = self.data;
         self.ligature_offsets()
             .iter()
@@ -1450,7 +1450,7 @@ impl<'a> ReverseChainSingleSubstFormat1<'a> {
     }
 
     /// Attempt to resolve [`backtrack_coverage_offsets`][Self::backtrack_coverage_offsets].
-    pub fn backtrack_coverage(
+    pub fn backtrack_coverages(
         &self,
     ) -> impl Iterator<Item = Result<CoverageTable<'a>, ReadError>> + 'a {
         let data = self.data;
@@ -1473,7 +1473,7 @@ impl<'a> ReverseChainSingleSubstFormat1<'a> {
     }
 
     /// Attempt to resolve [`lookahead_coverage_offsets`][Self::lookahead_coverage_offsets].
-    pub fn lookahead_coverage(
+    pub fn lookahead_coverages(
         &self,
     ) -> impl Iterator<Item = Result<CoverageTable<'a>, ReadError>> + 'a {
         let data = self.data;

--- a/read-fonts/generated/generated_layout.rs
+++ b/read-fonts/generated/generated_layout.rs
@@ -686,7 +686,7 @@ impl<'a, T> LookupList<'a, T> {
     }
 
     /// Attempt to resolve [`lookup_offsets`][Self::lookup_offsets].
-    pub fn lookup(&self) -> impl Iterator<Item = Result<T, ReadError>> + 'a
+    pub fn lookups(&self) -> impl Iterator<Item = Result<T, ReadError>> + 'a
     where
         T: FontRead<'a>,
     {
@@ -834,7 +834,7 @@ impl<'a, T> Lookup<'a, T> {
     }
 
     /// Attempt to resolve [`subtable_offsets`][Self::subtable_offsets].
-    pub fn subtable(&self) -> impl Iterator<Item = Result<T, ReadError>> + 'a
+    pub fn subtables(&self) -> impl Iterator<Item = Result<T, ReadError>> + 'a
     where
         T: FontRead<'a>,
     {
@@ -1572,7 +1572,7 @@ impl<'a> SequenceContextFormat1<'a> {
     }
 
     /// Attempt to resolve [`seq_rule_set_offsets`][Self::seq_rule_set_offsets].
-    pub fn seq_rule_set(
+    pub fn seq_rule_sets(
         &self,
     ) -> impl Iterator<Item = Option<Result<SequenceRuleSet<'a>, ReadError>>> + 'a {
         let data = self.data;
@@ -1670,7 +1670,7 @@ impl<'a> SequenceRuleSet<'a> {
     }
 
     /// Attempt to resolve [`seq_rule_offsets`][Self::seq_rule_offsets].
-    pub fn seq_rule(&self) -> impl Iterator<Item = Result<SequenceRule<'a>, ReadError>> + 'a {
+    pub fn seq_rules(&self) -> impl Iterator<Item = Result<SequenceRule<'a>, ReadError>> + 'a {
         let data = self.data;
         self.seq_rule_offsets()
             .iter()
@@ -1917,7 +1917,7 @@ impl<'a> SequenceContextFormat2<'a> {
     }
 
     /// Attempt to resolve [`class_seq_rule_set_offsets`][Self::class_seq_rule_set_offsets].
-    pub fn class_seq_rule_set(
+    pub fn class_seq_rule_sets(
         &self,
     ) -> impl Iterator<Item = Option<Result<ClassSequenceRuleSet<'a>, ReadError>>> + 'a {
         let data = self.data;
@@ -2023,7 +2023,7 @@ impl<'a> ClassSequenceRuleSet<'a> {
     }
 
     /// Attempt to resolve [`class_seq_rule_offsets`][Self::class_seq_rule_offsets].
-    pub fn class_seq_rule(
+    pub fn class_seq_rules(
         &self,
     ) -> impl Iterator<Item = Result<ClassSequenceRule<'a>, ReadError>> + 'a {
         let data = self.data;
@@ -2259,7 +2259,7 @@ impl<'a> SequenceContextFormat3<'a> {
     }
 
     /// Attempt to resolve [`coverage_offsets`][Self::coverage_offsets].
-    pub fn coverage(&self) -> impl Iterator<Item = Result<CoverageTable<'a>, ReadError>> + 'a {
+    pub fn coverages(&self) -> impl Iterator<Item = Result<CoverageTable<'a>, ReadError>> + 'a {
         let data = self.data;
         self.coverage_offsets()
             .iter()
@@ -2446,7 +2446,7 @@ impl<'a> ChainedSequenceContextFormat1<'a> {
     }
 
     /// Attempt to resolve [`chained_seq_rule_set_offsets`][Self::chained_seq_rule_set_offsets].
-    pub fn chained_seq_rule_set(
+    pub fn chained_seq_rule_sets(
         &self,
     ) -> impl Iterator<Item = Option<Result<ChainedSequenceRuleSet<'a>, ReadError>>> + 'a {
         let data = self.data;
@@ -2548,7 +2548,7 @@ impl<'a> ChainedSequenceRuleSet<'a> {
     }
 
     /// Attempt to resolve [`chained_seq_rule_offsets`][Self::chained_seq_rule_offsets].
-    pub fn chained_seq_rule(
+    pub fn chained_seq_rules(
         &self,
     ) -> impl Iterator<Item = Result<ChainedSequenceRule<'a>, ReadError>> + 'a {
         let data = self.data;
@@ -2896,7 +2896,7 @@ impl<'a> ChainedSequenceContextFormat2<'a> {
     }
 
     /// Attempt to resolve [`chained_class_seq_rule_set_offsets`][Self::chained_class_seq_rule_set_offsets].
-    pub fn chained_class_seq_rule_set(
+    pub fn chained_class_seq_rule_sets(
         &self,
     ) -> impl Iterator<Item = Option<Result<ChainedClassSequenceRuleSet<'a>, ReadError>>> + 'a {
         let data = self.data;
@@ -3016,7 +3016,7 @@ impl<'a> ChainedClassSequenceRuleSet<'a> {
     }
 
     /// Attempt to resolve [`chained_class_seq_rule_offsets`][Self::chained_class_seq_rule_offsets].
-    pub fn chained_class_seq_rule(
+    pub fn chained_class_seq_rules(
         &self,
     ) -> impl Iterator<Item = Result<ChainedClassSequenceRule<'a>, ReadError>> + 'a {
         let data = self.data;
@@ -3333,7 +3333,7 @@ impl<'a> ChainedSequenceContextFormat3<'a> {
     }
 
     /// Attempt to resolve [`backtrack_coverage_offsets`][Self::backtrack_coverage_offsets].
-    pub fn backtrack_coverage(
+    pub fn backtrack_coverages(
         &self,
     ) -> impl Iterator<Item = Result<CoverageTable<'a>, ReadError>> + 'a {
         let data = self.data;
@@ -3355,7 +3355,7 @@ impl<'a> ChainedSequenceContextFormat3<'a> {
     }
 
     /// Attempt to resolve [`input_coverage_offsets`][Self::input_coverage_offsets].
-    pub fn input_coverage(
+    pub fn input_coverages(
         &self,
     ) -> impl Iterator<Item = Result<CoverageTable<'a>, ReadError>> + 'a {
         let data = self.data;
@@ -3377,7 +3377,7 @@ impl<'a> ChainedSequenceContextFormat3<'a> {
     }
 
     /// Attempt to resolve [`lookahead_coverage_offsets`][Self::lookahead_coverage_offsets].
-    pub fn lookahead_coverage(
+    pub fn lookahead_coverages(
         &self,
     ) -> impl Iterator<Item = Result<CoverageTable<'a>, ReadError>> + 'a {
         let data = self.data;
@@ -3959,7 +3959,7 @@ impl<'a> ConditionSet<'a> {
     }
 
     /// Attempt to resolve [`condition_offsets`][Self::condition_offsets].
-    pub fn condition(&self) -> impl Iterator<Item = Result<ConditionFormat1<'a>, ReadError>> + 'a {
+    pub fn conditions(&self) -> impl Iterator<Item = Result<ConditionFormat1<'a>, ReadError>> + 'a {
         let data = self.data;
         self.condition_offsets()
             .iter()

--- a/read-fonts/generated/generated_test.rs
+++ b/read-fonts/generated/generated_test.rs
@@ -264,7 +264,7 @@ impl<'a> KindsOfArraysOfOffsets<'a> {
     }
 
     /// Attempt to resolve [`nonnullable_offsets`][Self::nonnullable_offsets].
-    pub fn nonnullable(&self) -> impl Iterator<Item = Result<Dummy<'a>, ReadError>> + 'a {
+    pub fn nonnullables(&self) -> impl Iterator<Item = Result<Dummy<'a>, ReadError>> + 'a {
         let data = self.data;
         self.nonnullable_offsets()
             .iter()
@@ -278,7 +278,7 @@ impl<'a> KindsOfArraysOfOffsets<'a> {
     }
 
     /// Attempt to resolve [`nullable_offsets`][Self::nullable_offsets].
-    pub fn nullable(&self) -> impl Iterator<Item = Option<Result<Dummy<'a>, ReadError>>> + 'a {
+    pub fn nullables(&self) -> impl Iterator<Item = Option<Result<Dummy<'a>, ReadError>>> + 'a {
         let data = self.data;
         self.nullable_offsets()
             .iter()
@@ -292,7 +292,7 @@ impl<'a> KindsOfArraysOfOffsets<'a> {
     }
 
     /// Attempt to resolve [`versioned_nonnullable_offsets`][Self::versioned_nonnullable_offsets].
-    pub fn versioned_nonnullable(
+    pub fn versioned_nonnullables(
         &self,
     ) -> Option<impl Iterator<Item = Result<Dummy<'a>, ReadError>> + 'a> {
         let data = self.data;
@@ -307,7 +307,7 @@ impl<'a> KindsOfArraysOfOffsets<'a> {
     }
 
     /// Attempt to resolve [`versioned_nullable_offsets`][Self::versioned_nullable_offsets].
-    pub fn versioned_nullable(
+    pub fn versioned_nullables(
         &self,
     ) -> Option<impl Iterator<Item = Option<Result<Dummy<'a>, ReadError>>> + 'a> {
         let data = self.data;

--- a/read-fonts/src/tests/gpos.rs
+++ b/read-fonts/src/tests/gpos.rs
@@ -43,8 +43,8 @@ fn pairposformat1() {
     assert_eq!(table.value_format2(), ValueFormat::X_PLACEMENT);
     assert_eq!(table.pair_set_count(), 2);
 
-    let set1 = table.pair_set().next().unwrap().unwrap();
-    let set2 = table.pair_set().nth(1).unwrap().unwrap();
+    let set1 = table.pair_sets().next().unwrap().unwrap();
+    let set2 = table.pair_sets().nth(1).unwrap().unwrap();
     assert_eq!(set1.pair_value_records().iter().count(), 1);
     assert_eq!(set2.pair_value_records().iter().count(), 1);
 
@@ -124,7 +124,7 @@ fn markligposformat1() {
     let table = MarkLigPosFormat1::read(test_data::MARKLIGPOSFORMAT1).unwrap();
     let lig_array = table.ligature_array().unwrap();
     assert_eq!(lig_array.ligature_count(), 1);
-    let lig_attach = lig_array.ligature_attach().next().unwrap().unwrap();
+    let lig_attach = lig_array.ligature_attaches().next().unwrap().unwrap();
     assert_eq!(lig_attach.component_count(), 3);
     let comp_record = lig_attach
         .component_records()

--- a/read-fonts/src/tests/test_gdef.rs
+++ b/read-fonts/src/tests/test_gdef.rs
@@ -25,7 +25,7 @@ fn attach_list_table() {
     let table = AttachList::read(test_data::ATTACHLIST_TABLE).unwrap();
     assert_eq!(table.glyph_count(), 2);
     assert_eq!(table.attach_point_offsets().len(), 2);
-    let attach_point = table.attach_point().nth(1).unwrap().unwrap();
+    let attach_point = table.attach_points().nth(1).unwrap().unwrap();
     assert_eq!(attach_point.point_indices()[0].get(), 14);
     assert_eq!(attach_point.point_indices()[1].get(), 23);
 }
@@ -33,8 +33,8 @@ fn attach_list_table() {
 #[test]
 fn lig_caret_list() {
     let table = LigCaretList::read(test_data::LIGCARETLIST_TABLE).unwrap();
-    let glyph1 = table.lig_glyph().next().unwrap().unwrap();
-    let glyph2 = table.lig_glyph().nth(1).unwrap().unwrap();
+    let glyph1 = table.lig_glyphs().next().unwrap().unwrap();
+    let glyph2 = table.lig_glyphs().nth(1).unwrap().unwrap();
     assert_eq!(glyph1.caret_value_offsets().len(), 1);
     assert_eq!(glyph2.caret_value_offsets().len(), 2);
     let g1c0: CaretValueFormat1 = glyph1.caret_value_offsets()[0]

--- a/read-fonts/src/tests/test_gsub.rs
+++ b/read-fonts/src/tests/test_gsub.rs
@@ -27,8 +27,8 @@ fn singlesubstformat2() {
 fn multiplesubstformat1() {
     // https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#example-4-multiplesubstformat1-subtable
     let table = MultipleSubstFormat1::read(test_data::MULTIPLESUBSTFORMAT1_TABLE).unwrap();
-    assert_eq!(table.sequence().count(), 1);
-    let seq0 = table.sequence().next().unwrap().unwrap();
+    assert_eq!(table.sequences().count(), 1);
+    let seq0 = table.sequences().next().unwrap().unwrap();
     assert_eq!(
         seq0.substitute_glyph_ids(),
         &[GlyphId::new(26), GlyphId::new(26), GlyphId::new(29)]
@@ -39,8 +39,8 @@ fn multiplesubstformat1() {
 fn alternatesubstformat1() {
     // https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#example-5-alternatesubstformat-1-subtable
     let table = AlternateSubstFormat1::read(test_data::ALTERNATESUBSTFORMAT1_TABLE).unwrap();
-    assert_eq!(table.alternate_set().count(), 1);
-    let altset0 = table.alternate_set().next().unwrap().unwrap();
+    assert_eq!(table.alternate_sets().count(), 1);
+    let altset0 = table.alternate_sets().next().unwrap().unwrap();
     assert_eq!(
         altset0.alternate_glyph_ids(),
         &[GlyphId::new(0xc9), GlyphId::new(0xca)]
@@ -51,19 +51,19 @@ fn alternatesubstformat1() {
 fn ligaturesubstformat1() {
     // https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#example-6-ligaturesubstformat1-subtable
     let table = LigatureSubstFormat1::read(test_data::LIGATURESUBSTFORMAT1_TABLE).unwrap();
-    assert_eq!(table.ligature_set().count(), 2);
-    let ligset0 = table.ligature_set().next().unwrap().unwrap();
+    assert_eq!(table.ligature_sets().count(), 2);
+    let ligset0 = table.ligature_sets().next().unwrap().unwrap();
 
-    assert_eq!(ligset0.ligature().count(), 1);
-    let lig0 = ligset0.ligature().next().unwrap().unwrap();
+    assert_eq!(ligset0.ligatures().count(), 1);
+    let lig0 = ligset0.ligatures().next().unwrap().unwrap();
     assert_eq!(lig0.ligature_glyph(), GlyphId::new(347));
     assert_eq!(
         lig0.component_glyph_ids(),
         &[GlyphId::new(0x28), GlyphId::new(0x17)]
     );
 
-    let ligset1 = table.ligature_set().nth(1).unwrap().unwrap();
-    let lig0 = ligset1.ligature().next().unwrap().unwrap();
+    let ligset1 = table.ligature_sets().nth(1).unwrap().unwrap();
+    let lig0 = ligset1.ligatures().next().unwrap().unwrap();
     assert_eq!(lig0.ligature_glyph(), GlyphId::new(0xf1));
     assert_eq!(
         lig0.component_glyph_ids(),

--- a/write-fonts/generated/generated_gdef.rs
+++ b/write-fonts/generated/generated_gdef.rs
@@ -157,7 +157,7 @@ impl<'a> FromObjRef<read_fonts::layout::gdef::AttachList<'a>> for AttachList {
     fn from_obj_ref(obj: &read_fonts::layout::gdef::AttachList<'a>, _: FontData) -> Self {
         AttachList {
             coverage_offset: obj.coverage().into(),
-            attach_point_offsets: obj.attach_point().map(|x| x.into()).collect(),
+            attach_point_offsets: obj.attach_points().map(|x| x.into()).collect(),
         }
     }
 }
@@ -258,7 +258,7 @@ impl<'a> FromObjRef<read_fonts::layout::gdef::LigCaretList<'a>> for LigCaretList
     fn from_obj_ref(obj: &read_fonts::layout::gdef::LigCaretList<'a>, _: FontData) -> Self {
         LigCaretList {
             coverage_offset: obj.coverage().into(),
-            lig_glyph_offsets: obj.lig_glyph().map(|x| x.into()).collect(),
+            lig_glyph_offsets: obj.lig_glyphs().map(|x| x.into()).collect(),
         }
     }
 }
@@ -306,7 +306,7 @@ impl Validate for LigGlyph {
 impl<'a> FromObjRef<read_fonts::layout::gdef::LigGlyph<'a>> for LigGlyph {
     fn from_obj_ref(obj: &read_fonts::layout::gdef::LigGlyph<'a>, _: FontData) -> Self {
         LigGlyph {
-            caret_value_offsets: obj.caret_value().map(|x| x.into()).collect(),
+            caret_value_offsets: obj.caret_values().map(|x| x.into()).collect(),
         }
     }
 }
@@ -534,7 +534,7 @@ impl Validate for MarkGlyphSets {
 impl<'a> FromObjRef<read_fonts::layout::gdef::MarkGlyphSets<'a>> for MarkGlyphSets {
     fn from_obj_ref(obj: &read_fonts::layout::gdef::MarkGlyphSets<'a>, _: FontData) -> Self {
         MarkGlyphSets {
-            coverage_offsets: obj.coverage().map(|x| x.into()).collect(),
+            coverage_offsets: obj.coverages().map(|x| x.into()).collect(),
         }
     }
 }

--- a/write-fonts/generated/generated_gpos.rs
+++ b/write-fonts/generated/generated_gpos.rs
@@ -707,7 +707,7 @@ impl<'a> FromObjRef<read_fonts::layout::gpos::PairPosFormat1<'a>> for PairPosFor
     fn from_obj_ref(obj: &read_fonts::layout::gpos::PairPosFormat1<'a>, _: FontData) -> Self {
         PairPosFormat1 {
             coverage_offset: obj.coverage().into(),
-            pair_set_offsets: obj.pair_set().map(|x| x.into()).collect(),
+            pair_set_offsets: obj.pair_sets().map(|x| x.into()).collect(),
         }
     }
 }
@@ -1209,7 +1209,7 @@ impl Validate for BaseRecord {
 impl FromObjRef<read_fonts::layout::gpos::BaseRecord<'_>> for BaseRecord {
     fn from_obj_ref(obj: &read_fonts::layout::gpos::BaseRecord, offset_data: FontData) -> Self {
         BaseRecord {
-            base_anchor_offsets: obj.base_anchor(offset_data).map(|x| x.into()).collect(),
+            base_anchor_offsets: obj.base_anchors(offset_data).map(|x| x.into()).collect(),
         }
     }
 }
@@ -1319,7 +1319,7 @@ impl Validate for LigatureArray {
 impl<'a> FromObjRef<read_fonts::layout::gpos::LigatureArray<'a>> for LigatureArray {
     fn from_obj_ref(obj: &read_fonts::layout::gpos::LigatureArray<'a>, _: FontData) -> Self {
         LigatureArray {
-            ligature_attach_offsets: obj.ligature_attach().map(|x| x.into()).collect(),
+            ligature_attach_offsets: obj.ligature_attaches().map(|x| x.into()).collect(),
         }
     }
 }
@@ -1407,7 +1407,10 @@ impl FromObjRef<read_fonts::layout::gpos::ComponentRecord<'_>> for ComponentReco
         offset_data: FontData,
     ) -> Self {
         ComponentRecord {
-            ligature_anchor_offsets: obj.ligature_anchor(offset_data).map(|x| x.into()).collect(),
+            ligature_anchor_offsets: obj
+                .ligature_anchors(offset_data)
+                .map(|x| x.into())
+                .collect(),
         }
     }
 }
@@ -1560,7 +1563,7 @@ impl Validate for Mark2Record {
 impl FromObjRef<read_fonts::layout::gpos::Mark2Record<'_>> for Mark2Record {
     fn from_obj_ref(obj: &read_fonts::layout::gpos::Mark2Record, offset_data: FontData) -> Self {
         Mark2Record {
-            mark2_anchor_offsets: obj.mark2_anchor(offset_data).map(|x| x.into()).collect(),
+            mark2_anchor_offsets: obj.mark2_anchors(offset_data).map(|x| x.into()).collect(),
         }
     }
 }

--- a/write-fonts/generated/generated_gsub.rs
+++ b/write-fonts/generated/generated_gsub.rs
@@ -349,7 +349,7 @@ impl<'a> FromObjRef<read_fonts::layout::gsub::MultipleSubstFormat1<'a>> for Mult
     fn from_obj_ref(obj: &read_fonts::layout::gsub::MultipleSubstFormat1<'a>, _: FontData) -> Self {
         MultipleSubstFormat1 {
             coverage_offset: obj.coverage().into(),
-            sequence_offsets: obj.sequence().map(|x| x.into()).collect(),
+            sequence_offsets: obj.sequences().map(|x| x.into()).collect(),
         }
     }
 }
@@ -456,7 +456,7 @@ impl<'a> FromObjRef<read_fonts::layout::gsub::AlternateSubstFormat1<'a>> for Alt
     ) -> Self {
         AlternateSubstFormat1 {
             coverage_offset: obj.coverage().into(),
-            alternate_set_offsets: obj.alternate_set().map(|x| x.into()).collect(),
+            alternate_set_offsets: obj.alternate_sets().map(|x| x.into()).collect(),
         }
     }
 }
@@ -563,7 +563,7 @@ impl<'a> FromObjRef<read_fonts::layout::gsub::LigatureSubstFormat1<'a>> for Liga
     fn from_obj_ref(obj: &read_fonts::layout::gsub::LigatureSubstFormat1<'a>, _: FontData) -> Self {
         LigatureSubstFormat1 {
             coverage_offset: obj.coverage().into(),
-            ligature_set_offsets: obj.ligature_set().map(|x| x.into()).collect(),
+            ligature_set_offsets: obj.ligature_sets().map(|x| x.into()).collect(),
         }
     }
 }
@@ -612,7 +612,7 @@ impl Validate for LigatureSet {
 impl<'a> FromObjRef<read_fonts::layout::gsub::LigatureSet<'a>> for LigatureSet {
     fn from_obj_ref(obj: &read_fonts::layout::gsub::LigatureSet<'a>, _: FontData) -> Self {
         LigatureSet {
-            ligature_offsets: obj.ligature().map(|x| x.into()).collect(),
+            ligature_offsets: obj.ligatures().map(|x| x.into()).collect(),
         }
     }
 }
@@ -861,8 +861,8 @@ impl<'a> FromObjRef<read_fonts::layout::gsub::ReverseChainSingleSubstFormat1<'a>
     ) -> Self {
         ReverseChainSingleSubstFormat1 {
             coverage_offset: obj.coverage().into(),
-            backtrack_coverage_offsets: obj.backtrack_coverage().map(|x| x.into()).collect(),
-            lookahead_coverage_offsets: obj.lookahead_coverage().map(|x| x.into()).collect(),
+            backtrack_coverage_offsets: obj.backtrack_coverages().map(|x| x.into()).collect(),
+            lookahead_coverage_offsets: obj.lookahead_coverages().map(|x| x.into()).collect(),
             substitute_glyph_ids: obj.substitute_glyph_ids().iter().map(|x| x.get()).collect(),
         }
     }

--- a/write-fonts/generated/generated_layout.rs
+++ b/write-fonts/generated/generated_layout.rs
@@ -413,7 +413,7 @@ where
 {
     fn from_obj_ref(obj: &read_fonts::layout::LookupList<'a, U>, _: FontData) -> Self {
         LookupList {
-            lookup_offsets: obj.lookup().map(|x| x.into()).collect(),
+            lookup_offsets: obj.lookups().map(|x| x.into()).collect(),
         }
     }
 }
@@ -462,7 +462,7 @@ where
     fn from_obj_ref(obj: &read_fonts::layout::Lookup<'a, U>, _: FontData) -> Self {
         Lookup {
             lookup_flag: obj.lookup_flag(),
-            subtable_offsets: obj.subtable().map(|x| x.into()).collect(),
+            subtable_offsets: obj.subtables().map(|x| x.into()).collect(),
             mark_filtering_set: obj.mark_filtering_set(),
         }
     }
@@ -918,7 +918,7 @@ impl<'a> FromObjRef<read_fonts::layout::SequenceContextFormat1<'a>> for Sequence
     fn from_obj_ref(obj: &read_fonts::layout::SequenceContextFormat1<'a>, _: FontData) -> Self {
         SequenceContextFormat1 {
             coverage_offset: obj.coverage().into(),
-            seq_rule_set_offsets: obj.seq_rule_set().map(|x| x.into()).collect(),
+            seq_rule_set_offsets: obj.seq_rule_sets().map(|x| x.into()).collect(),
         }
     }
 }
@@ -967,7 +967,7 @@ impl Validate for SequenceRuleSet {
 impl<'a> FromObjRef<read_fonts::layout::SequenceRuleSet<'a>> for SequenceRuleSet {
     fn from_obj_ref(obj: &read_fonts::layout::SequenceRuleSet<'a>, _: FontData) -> Self {
         SequenceRuleSet {
-            seq_rule_offsets: obj.seq_rule().map(|x| x.into()).collect(),
+            seq_rule_offsets: obj.seq_rules().map(|x| x.into()).collect(),
         }
     }
 }
@@ -1089,7 +1089,7 @@ impl<'a> FromObjRef<read_fonts::layout::SequenceContextFormat2<'a>> for Sequence
         SequenceContextFormat2 {
             coverage_offset: obj.coverage().into(),
             class_def_offset: obj.class_def().into(),
-            class_seq_rule_set_offsets: obj.class_seq_rule_set().map(|x| x.into()).collect(),
+            class_seq_rule_set_offsets: obj.class_seq_rule_sets().map(|x| x.into()).collect(),
         }
     }
 }
@@ -1138,7 +1138,7 @@ impl Validate for ClassSequenceRuleSet {
 impl<'a> FromObjRef<read_fonts::layout::ClassSequenceRuleSet<'a>> for ClassSequenceRuleSet {
     fn from_obj_ref(obj: &read_fonts::layout::ClassSequenceRuleSet<'a>, _: FontData) -> Self {
         ClassSequenceRuleSet {
-            class_seq_rule_offsets: obj.class_seq_rule().map(|x| x.into()).collect(),
+            class_seq_rule_offsets: obj.class_seq_rules().map(|x| x.into()).collect(),
         }
     }
 }
@@ -1257,7 +1257,7 @@ impl<'a> FromObjRef<read_fonts::layout::SequenceContextFormat3<'a>> for Sequence
     fn from_obj_ref(obj: &read_fonts::layout::SequenceContextFormat3<'a>, _: FontData) -> Self {
         let offset_data = obj.offset_data();
         SequenceContextFormat3 {
-            coverage_offsets: obj.coverage().map(|x| x.into()).collect(),
+            coverage_offsets: obj.coverages().map(|x| x.into()).collect(),
             seq_lookup_records: obj
                 .seq_lookup_records()
                 .iter()
@@ -1374,7 +1374,7 @@ impl<'a> FromObjRef<read_fonts::layout::ChainedSequenceContextFormat1<'a>>
     ) -> Self {
         ChainedSequenceContextFormat1 {
             coverage_offset: obj.coverage().into(),
-            chained_seq_rule_set_offsets: obj.chained_seq_rule_set().map(|x| x.into()).collect(),
+            chained_seq_rule_set_offsets: obj.chained_seq_rule_sets().map(|x| x.into()).collect(),
         }
     }
 }
@@ -1426,7 +1426,7 @@ impl Validate for ChainedSequenceRuleSet {
 impl<'a> FromObjRef<read_fonts::layout::ChainedSequenceRuleSet<'a>> for ChainedSequenceRuleSet {
     fn from_obj_ref(obj: &read_fonts::layout::ChainedSequenceRuleSet<'a>, _: FontData) -> Self {
         ChainedSequenceRuleSet {
-            chained_seq_rule_offsets: obj.chained_seq_rule().map(|x| x.into()).collect(),
+            chained_seq_rule_offsets: obj.chained_seq_rules().map(|x| x.into()).collect(),
         }
     }
 }
@@ -1592,7 +1592,7 @@ impl<'a> FromObjRef<read_fonts::layout::ChainedSequenceContextFormat2<'a>>
             input_class_def_offset: obj.input_class_def().into(),
             lookahead_class_def_offset: obj.lookahead_class_def().into(),
             chained_class_seq_rule_set_offsets: obj
-                .chained_class_seq_rule_set()
+                .chained_class_seq_rule_sets()
                 .map(|x| x.into())
                 .collect(),
         }
@@ -1652,7 +1652,7 @@ impl<'a> FromObjRef<read_fonts::layout::ChainedClassSequenceRuleSet<'a>>
     ) -> Self {
         ChainedClassSequenceRuleSet {
             chained_class_seq_rule_offsets: obj
-                .chained_class_seq_rule()
+                .chained_class_seq_rules()
                 .map(|x| x.into())
                 .collect(),
         }
@@ -1824,9 +1824,9 @@ impl<'a> FromObjRef<read_fonts::layout::ChainedSequenceContextFormat3<'a>>
     ) -> Self {
         let offset_data = obj.offset_data();
         ChainedSequenceContextFormat3 {
-            backtrack_coverage_offsets: obj.backtrack_coverage().map(|x| x.into()).collect(),
-            input_coverage_offsets: obj.input_coverage().map(|x| x.into()).collect(),
-            lookahead_coverage_offsets: obj.lookahead_coverage().map(|x| x.into()).collect(),
+            backtrack_coverage_offsets: obj.backtrack_coverages().map(|x| x.into()).collect(),
+            input_coverage_offsets: obj.input_coverages().map(|x| x.into()).collect(),
+            lookahead_coverage_offsets: obj.lookahead_coverages().map(|x| x.into()).collect(),
             seq_lookup_records: obj
                 .seq_lookup_records()
                 .iter()
@@ -2151,7 +2151,7 @@ impl Validate for ConditionSet {
 impl<'a> FromObjRef<read_fonts::layout::ConditionSet<'a>> for ConditionSet {
     fn from_obj_ref(obj: &read_fonts::layout::ConditionSet<'a>, _: FontData) -> Self {
         ConditionSet {
-            condition_offsets: obj.condition().map(|x| x.into()).collect(),
+            condition_offsets: obj.conditions().map(|x| x.into()).collect(),
         }
     }
 }

--- a/write-fonts/generated/generated_test.rs
+++ b/write-fonts/generated/generated_test.rs
@@ -182,13 +182,13 @@ impl<'a> FromObjRef<read_fonts::codegen_test::KindsOfArraysOfOffsets<'a>>
         KindsOfArraysOfOffsets {
             version: obj.version(),
             count: obj.count(),
-            nonnullable_offsets: obj.nonnullable().map(|x| x.into()).collect(),
-            nullable_offsets: obj.nullable().map(|x| x.into()).collect(),
+            nonnullable_offsets: obj.nonnullables().map(|x| x.into()).collect(),
+            nullable_offsets: obj.nullables().map(|x| x.into()).collect(),
             versioned_nonnullable_offsets: obj
-                .versioned_nonnullable()
+                .versioned_nonnullables()
                 .map(|obj| obj.map(|x| x.into()).collect()),
             versioned_nullable_offsets: obj
-                .versioned_nullable()
+                .versioned_nullables()
                 .map(|obj| obj.map(|x| x.into()).collect()),
         }
     }


### PR DESCRIPTION
This is based on the name of the getter in the spec: if the raw getter is pluralized, we will pluralize the resolved getter.

For instance, for the raw 'attach_point_offsets' field, we will generate 'attach_points', but for 'attach_point_offset' we will generate 'attach_point'.