### PR TITLE
Remove FontInfo/FontInfoWithArgs traits

### DIFF
--- a/read-fonts/generated/font.rs
+++ b/read-fonts/generated/font.rs
@@ -39,9 +39,8 @@ impl TableDirectoryMarker {
     }
 }
 
-impl TableInfo for TableDirectoryMarker {
-    #[allow(unused_parens)]
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for TableDirectory<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         cursor.advance::<u32>();
         let num_tables: u16 = cursor.read()?;

--- a/read-fonts/generated/generated_cmap.rs
+++ b/read-fonts/generated/generated_cmap.rs
@@ -27,9 +27,8 @@ impl CmapMarker {
     }
 }
 
-impl TableInfo for CmapMarker {
-    #[allow(unused_parens)]
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for Cmap<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         cursor.advance::<u16>();
         let num_tables: u16 = cursor.read()?;
@@ -293,9 +292,8 @@ impl Cmap0Marker {
     }
 }
 
-impl TableInfo for Cmap0Marker {
-    #[allow(unused_parens)]
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for Cmap0<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         cursor.advance::<u16>();
         cursor.advance::<u16>();
@@ -391,9 +389,8 @@ impl Cmap2Marker {
     }
 }
 
-impl TableInfo for Cmap2Marker {
-    #[allow(unused_parens)]
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for Cmap2<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         cursor.advance::<u16>();
         cursor.advance::<u16>();
@@ -589,9 +586,8 @@ impl Cmap4Marker {
     }
 }
 
-impl TableInfo for Cmap4Marker {
-    #[allow(unused_parens)]
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for Cmap4<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         cursor.advance::<u16>();
         cursor.advance::<u16>();
@@ -772,9 +768,8 @@ impl Cmap6Marker {
     }
 }
 
-impl TableInfo for Cmap6Marker {
-    #[allow(unused_parens)]
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for Cmap6<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         cursor.advance::<u16>();
         cursor.advance::<u16>();
@@ -899,9 +894,8 @@ impl Cmap8Marker {
     }
 }
 
-impl TableInfo for Cmap8Marker {
-    #[allow(unused_parens)]
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for Cmap8<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         cursor.advance::<u16>();
         cursor.advance::<u16>();
@@ -1095,9 +1089,8 @@ impl Cmap10Marker {
     }
 }
 
-impl TableInfo for Cmap10Marker {
-    #[allow(unused_parens)]
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for Cmap10<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         cursor.advance::<u16>();
         cursor.advance::<u16>();
@@ -1218,9 +1211,8 @@ impl Cmap12Marker {
     }
 }
 
-impl TableInfo for Cmap12Marker {
-    #[allow(unused_parens)]
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for Cmap12<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         cursor.advance::<u16>();
         cursor.advance::<u16>();
@@ -1338,9 +1330,8 @@ impl Cmap13Marker {
     }
 }
 
-impl TableInfo for Cmap13Marker {
-    #[allow(unused_parens)]
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for Cmap13<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         cursor.advance::<u16>();
         cursor.advance::<u16>();
@@ -1502,9 +1493,8 @@ impl Cmap14Marker {
     }
 }
 
-impl TableInfo for Cmap14Marker {
-    #[allow(unused_parens)]
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for Cmap14<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         cursor.advance::<u16>();
         cursor.advance::<u32>();
@@ -1659,9 +1649,8 @@ impl DefaultUvsMarker {
     }
 }
 
-impl TableInfo for DefaultUvsMarker {
-    #[allow(unused_parens)]
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for DefaultUvs<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         let num_unicode_value_ranges: u32 = cursor.read()?;
         let ranges_byte_len = num_unicode_value_ranges as usize * UnicodeRange::RAW_BYTE_LEN;

--- a/read-fonts/generated/generated_gdef.rs
+++ b/read-fonts/generated/generated_gdef.rs
@@ -44,8 +44,8 @@ impl GdefMarker {
     }
 }
 
-impl TableInfo for GdefMarker {
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for Gdef<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         let version: MajorMinor = cursor.read()?;
         cursor.advance::<Offset16>();
@@ -282,9 +282,8 @@ impl AttachListMarker {
     }
 }
 
-impl TableInfo for AttachListMarker {
-    #[allow(unused_parens)]
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for AttachList<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         cursor.advance::<Offset16>();
         let glyph_count: u16 = cursor.read()?;
@@ -390,9 +389,8 @@ impl AttachPointMarker {
     }
 }
 
-impl TableInfo for AttachPointMarker {
-    #[allow(unused_parens)]
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for AttachPoint<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         let point_count: u16 = cursor.read()?;
         let point_indices_byte_len = point_count as usize * u16::RAW_BYTE_LEN;
@@ -463,9 +461,8 @@ impl LigCaretListMarker {
     }
 }
 
-impl TableInfo for LigCaretListMarker {
-    #[allow(unused_parens)]
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for LigCaretList<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         cursor.advance::<Offset16>();
         let lig_glyph_count: u16 = cursor.read()?;
@@ -571,9 +568,8 @@ impl LigGlyphMarker {
     }
 }
 
-impl TableInfo for LigGlyphMarker {
-    #[allow(unused_parens)]
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for LigGlyph<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         let caret_count: u16 = cursor.read()?;
         let caret_value_offsets_byte_len = caret_count as usize * Offset16::RAW_BYTE_LEN;
@@ -711,8 +707,8 @@ impl CaretValueFormat1Marker {
     }
 }
 
-impl TableInfo for CaretValueFormat1Marker {
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for CaretValueFormat1<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         cursor.advance::<u16>();
         cursor.advance::<i16>();
@@ -778,8 +774,8 @@ impl CaretValueFormat2Marker {
     }
 }
 
-impl TableInfo for CaretValueFormat2Marker {
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for CaretValueFormat2<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         cursor.advance::<u16>();
         cursor.advance::<u16>();
@@ -852,8 +848,8 @@ impl CaretValueFormat3Marker {
     }
 }
 
-impl TableInfo for CaretValueFormat3Marker {
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for CaretValueFormat3<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         cursor.advance::<u16>();
         cursor.advance::<i16>();
@@ -944,9 +940,8 @@ impl MarkGlyphSetsMarker {
     }
 }
 
-impl TableInfo for MarkGlyphSetsMarker {
-    #[allow(unused_parens)]
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for MarkGlyphSets<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         cursor.advance::<u16>();
         let mark_glyph_set_count: u16 = cursor.read()?;

--- a/read-fonts/generated/generated_glyf.rs
+++ b/read-fonts/generated/generated_glyf.rs
@@ -12,8 +12,8 @@ pub struct GlyfMarker {}
 
 impl GlyfMarker {}
 
-impl TableInfo for GlyfMarker {
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for Glyf<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let cursor = data.cursor();
         cursor.finish(GlyfMarker {})
     }
@@ -94,9 +94,8 @@ impl SimpleGlyphMarker {
     }
 }
 
-impl TableInfo for SimpleGlyphMarker {
-    #[allow(unused_parens)]
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for SimpleGlyph<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         let number_of_contours: i16 = cursor.read()?;
         cursor.advance::<i16>();
@@ -267,9 +266,8 @@ impl CompositeGlyphMarker {
     }
 }
 
-impl TableInfo for CompositeGlyphMarker {
-    #[allow(unused_parens)]
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for CompositeGlyph<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         cursor.advance::<i16>();
         cursor.advance::<i16>();

--- a/read-fonts/generated/generated_gpos.rs
+++ b/read-fonts/generated/generated_gpos.rs
@@ -36,8 +36,8 @@ impl GposMarker {
     }
 }
 
-impl TableInfo for GposMarker {
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for Gpos<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         let version: MajorMinor = cursor.read()?;
         cursor.advance::<Offset16>();
@@ -305,8 +305,8 @@ impl AnchorFormat1Marker {
     }
 }
 
-impl TableInfo for AnchorFormat1Marker {
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for AnchorFormat1<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         cursor.advance::<u16>();
         cursor.advance::<i16>();
@@ -388,8 +388,8 @@ impl AnchorFormat2Marker {
     }
 }
 
-impl TableInfo for AnchorFormat2Marker {
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for AnchorFormat2<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         cursor.advance::<u16>();
         cursor.advance::<i16>();
@@ -483,8 +483,8 @@ impl AnchorFormat3Marker {
     }
 }
 
-impl TableInfo for AnchorFormat3Marker {
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for AnchorFormat3<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         cursor.advance::<u16>();
         cursor.advance::<i16>();
@@ -594,9 +594,8 @@ impl MarkArrayMarker {
     }
 }
 
-impl TableInfo for MarkArrayMarker {
-    #[allow(unused_parens)]
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for MarkArray<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         let mark_count: u16 = cursor.read()?;
         let mark_records_byte_len = mark_count as usize * MarkRecord::RAW_BYTE_LEN;
@@ -777,9 +776,8 @@ impl SinglePosFormat1Marker {
     }
 }
 
-impl TableInfo for SinglePosFormat1Marker {
-    #[allow(unused_parens)]
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for SinglePosFormat1<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         cursor.advance::<u16>();
         cursor.advance::<Offset16>();
@@ -890,9 +888,8 @@ impl SinglePosFormat2Marker {
     }
 }
 
-impl TableInfo for SinglePosFormat2Marker {
-    #[allow(unused_parens)]
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for SinglePosFormat2<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         cursor.advance::<u16>();
         cursor.advance::<Offset16>();
@@ -1067,9 +1064,8 @@ impl PairPosFormat1Marker {
     }
 }
 
-impl TableInfo for PairPosFormat1Marker {
-    #[allow(unused_parens)]
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for PairPosFormat1<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         cursor.advance::<u16>();
         cursor.advance::<Offset16>();
@@ -1205,16 +1201,16 @@ impl PairSetMarker {
     }
 }
 
-impl ReadArgs for PairSetMarker {
+impl ReadArgs for PairSet<'_> {
     type Args = (ValueFormat, ValueFormat);
 }
 
-impl TableInfoWithArgs for PairSetMarker {
+impl<'a> FontReadWithArgs<'a> for PairSet<'a> {
     #[allow(unused_parens)]
-    fn parse_with_args<'a>(
+    fn read_with_args(
         data: FontData<'a>,
         args: &(ValueFormat, ValueFormat),
-    ) -> Result<TableRef<'a, Self>, ReadError> {
+    ) -> Result<Self, ReadError> {
         let (value_format1, value_format2) = *args;
         let mut cursor = data.cursor();
         let pair_value_count: u16 = cursor.read()?;
@@ -1412,9 +1408,8 @@ impl PairPosFormat2Marker {
     }
 }
 
-impl TableInfo for PairPosFormat2Marker {
-    #[allow(unused_parens)]
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for PairPosFormat2<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         cursor.advance::<u16>();
         cursor.advance::<Offset16>();
@@ -1728,9 +1723,8 @@ impl CursivePosFormat1Marker {
     }
 }
 
-impl TableInfo for CursivePosFormat1Marker {
-    #[allow(unused_parens)]
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for CursivePosFormat1<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         cursor.advance::<u16>();
         cursor.advance::<Offset16>();
@@ -1915,8 +1909,8 @@ impl MarkBasePosFormat1Marker {
     }
 }
 
-impl TableInfo for MarkBasePosFormat1Marker {
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for MarkBasePosFormat1<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         cursor.advance::<u16>();
         cursor.advance::<Offset16>();
@@ -2054,16 +2048,13 @@ impl BaseArrayMarker {
     }
 }
 
-impl ReadArgs for BaseArrayMarker {
+impl ReadArgs for BaseArray<'_> {
     type Args = u16;
 }
 
-impl TableInfoWithArgs for BaseArrayMarker {
+impl<'a> FontReadWithArgs<'a> for BaseArray<'a> {
     #[allow(unused_parens)]
-    fn parse_with_args<'a>(
-        data: FontData<'a>,
-        args: &u16,
-    ) -> Result<TableRef<'a, Self>, ReadError> {
+    fn read_with_args(data: FontData<'a>, args: &u16) -> Result<Self, ReadError> {
         let mark_class_count = *args;
         let mut cursor = data.cursor();
         let base_count: u16 = cursor.read()?;
@@ -2240,8 +2231,8 @@ impl MarkLigPosFormat1Marker {
     }
 }
 
-impl TableInfo for MarkLigPosFormat1Marker {
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for MarkLigPosFormat1<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         cursor.advance::<u16>();
         cursor.advance::<Offset16>();
@@ -2379,16 +2370,13 @@ impl LigatureArrayMarker {
     }
 }
 
-impl ReadArgs for LigatureArrayMarker {
+impl ReadArgs for LigatureArray<'_> {
     type Args = u16;
 }
 
-impl TableInfoWithArgs for LigatureArrayMarker {
+impl<'a> FontReadWithArgs<'a> for LigatureArray<'a> {
     #[allow(unused_parens)]
-    fn parse_with_args<'a>(
-        data: FontData<'a>,
-        args: &u16,
-    ) -> Result<TableRef<'a, Self>, ReadError> {
+    fn read_with_args(data: FontData<'a>, args: &u16) -> Result<Self, ReadError> {
         let mark_class_count = *args;
         let mut cursor = data.cursor();
         let ligature_count: u16 = cursor.read()?;
@@ -2489,16 +2477,13 @@ impl LigatureAttachMarker {
     }
 }
 
-impl ReadArgs for LigatureAttachMarker {
+impl ReadArgs for LigatureAttach<'_> {
     type Args = u16;
 }
 
-impl TableInfoWithArgs for LigatureAttachMarker {
+impl<'a> FontReadWithArgs<'a> for LigatureAttach<'a> {
     #[allow(unused_parens)]
-    fn parse_with_args<'a>(
-        data: FontData<'a>,
-        args: &u16,
-    ) -> Result<TableRef<'a, Self>, ReadError> {
+    fn read_with_args(data: FontData<'a>, args: &u16) -> Result<Self, ReadError> {
         let mark_class_count = *args;
         let mut cursor = data.cursor();
         let component_count: u16 = cursor.read()?;
@@ -2675,8 +2660,8 @@ impl MarkMarkPosFormat1Marker {
     }
 }
 
-impl TableInfo for MarkMarkPosFormat1Marker {
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for MarkMarkPosFormat1<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         cursor.advance::<u16>();
         cursor.advance::<Offset16>();
@@ -2814,16 +2799,13 @@ impl Mark2ArrayMarker {
     }
 }
 
-impl ReadArgs for Mark2ArrayMarker {
+impl ReadArgs for Mark2Array<'_> {
     type Args = u16;
 }
 
-impl TableInfoWithArgs for Mark2ArrayMarker {
+impl<'a> FontReadWithArgs<'a> for Mark2Array<'a> {
     #[allow(unused_parens)]
-    fn parse_with_args<'a>(
-        data: FontData<'a>,
-        args: &u16,
-    ) -> Result<TableRef<'a, Self>, ReadError> {
+    fn read_with_args(data: FontData<'a>, args: &u16) -> Result<Self, ReadError> {
         let mark_class_count = *args;
         let mut cursor = data.cursor();
         let mark2_count: u16 = cursor.read()?;
@@ -3000,8 +2982,8 @@ impl<T> Clone for ExtensionPosFormat1Marker<T> {
 
 impl<T> Copy for ExtensionPosFormat1Marker<T> {}
 
-impl<T> TableInfo for ExtensionPosFormat1Marker<T> {
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a, T> FontRead<'a> for ExtensionPosFormat1<'a, T> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         cursor.advance::<u16>();
         cursor.advance::<u16>();

--- a/read-fonts/generated/generated_gsub.rs
+++ b/read-fonts/generated/generated_gsub.rs
@@ -35,8 +35,8 @@ impl GsubMarker {
     }
 }
 
-impl TableInfo for GsubMarker {
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for Gsub<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         let version: MajorMinor = cursor.read()?;
         cursor.advance::<Offset16>();
@@ -278,8 +278,8 @@ impl SingleSubstFormat1Marker {
     }
 }
 
-impl TableInfo for SingleSubstFormat1Marker {
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for SingleSubstFormat1<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         cursor.advance::<u16>();
         cursor.advance::<Offset16>();
@@ -373,9 +373,8 @@ impl SingleSubstFormat2Marker {
     }
 }
 
-impl TableInfo for SingleSubstFormat2Marker {
-    #[allow(unused_parens)]
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for SingleSubstFormat2<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         cursor.advance::<u16>();
         cursor.advance::<Offset16>();
@@ -483,9 +482,8 @@ impl MultipleSubstFormat1Marker {
     }
 }
 
-impl TableInfo for MultipleSubstFormat1Marker {
-    #[allow(unused_parens)]
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for MultipleSubstFormat1<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         cursor.advance::<u16>();
         cursor.advance::<Offset16>();
@@ -600,9 +598,8 @@ impl SequenceMarker {
     }
 }
 
-impl TableInfo for SequenceMarker {
-    #[allow(unused_parens)]
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for Sequence<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         let glyph_count: u16 = cursor.read()?;
         let substitute_glyph_ids_byte_len = glyph_count as usize * GlyphId::RAW_BYTE_LEN;
@@ -685,9 +682,8 @@ impl AlternateSubstFormat1Marker {
     }
 }
 
-impl TableInfo for AlternateSubstFormat1Marker {
-    #[allow(unused_parens)]
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for AlternateSubstFormat1<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         cursor.advance::<u16>();
         cursor.advance::<Offset16>();
@@ -805,9 +801,8 @@ impl AlternateSetMarker {
     }
 }
 
-impl TableInfo for AlternateSetMarker {
-    #[allow(unused_parens)]
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for AlternateSet<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         let glyph_count: u16 = cursor.read()?;
         let alternate_glyph_ids_byte_len = glyph_count as usize * GlyphId::RAW_BYTE_LEN;
@@ -889,9 +884,8 @@ impl LigatureSubstFormat1Marker {
     }
 }
 
-impl TableInfo for LigatureSubstFormat1Marker {
-    #[allow(unused_parens)]
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for LigatureSubstFormat1<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         cursor.advance::<u16>();
         cursor.advance::<Offset16>();
@@ -1006,9 +1000,8 @@ impl LigatureSetMarker {
     }
 }
 
-impl TableInfo for LigatureSetMarker {
-    #[allow(unused_parens)]
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for LigatureSet<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         let ligature_count: u16 = cursor.read()?;
         let ligature_offsets_byte_len = ligature_count as usize * Offset16::RAW_BYTE_LEN;
@@ -1101,9 +1094,8 @@ impl LigatureMarker {
     }
 }
 
-impl TableInfo for LigatureMarker {
-    #[allow(unused_parens)]
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for Ligature<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         cursor.advance::<GlyphId>();
         let component_count: u16 = cursor.read()?;
@@ -1200,8 +1192,8 @@ impl<T> Clone for ExtensionSubstFormat1Marker<T> {
 
 impl<T> Copy for ExtensionSubstFormat1Marker<T> {}
 
-impl<T> TableInfo for ExtensionSubstFormat1Marker<T> {
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a, T> FontRead<'a> for ExtensionSubstFormat1<'a, T> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         cursor.advance::<u16>();
         cursor.advance::<u16>();
@@ -1388,9 +1380,8 @@ impl ReverseChainSingleSubstFormat1Marker {
     }
 }
 
-impl TableInfo for ReverseChainSingleSubstFormat1Marker {
-    #[allow(unused_parens)]
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for ReverseChainSingleSubstFormat1<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         cursor.advance::<u16>();
         cursor.advance::<Offset16>();

--- a/read-fonts/generated/generated_head.rs
+++ b/read-fonts/generated/generated_head.rs
@@ -81,8 +81,8 @@ impl HeadMarker {
     }
 }
 
-impl TableInfo for HeadMarker {
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for Head<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         cursor.advance::<MajorMinor>();
         cursor.advance::<Fixed>();

--- a/read-fonts/generated/generated_hhea.rs
+++ b/read-fonts/generated/generated_hhea.rs
@@ -81,8 +81,8 @@ impl HheaMarker {
     }
 }
 
-impl TableInfo for HheaMarker {
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for Hhea<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         cursor.advance::<MajorMinor>();
         cursor.advance::<FWord>();

--- a/read-fonts/generated/generated_hmtx.rs
+++ b/read-fonts/generated/generated_hmtx.rs
@@ -24,16 +24,13 @@ impl HmtxMarker {
     }
 }
 
-impl ReadArgs for HmtxMarker {
+impl ReadArgs for Hmtx<'_> {
     type Args = (u16, u16);
 }
 
-impl TableInfoWithArgs for HmtxMarker {
+impl<'a> FontReadWithArgs<'a> for Hmtx<'a> {
     #[allow(unused_parens)]
-    fn parse_with_args<'a>(
-        data: FontData<'a>,
-        args: &(u16, u16),
-    ) -> Result<TableRef<'a, Self>, ReadError> {
+    fn read_with_args(data: FontData<'a>, args: &(u16, u16)) -> Result<Self, ReadError> {
         let (number_of_h_metrics, num_glyphs) = *args;
         let mut cursor = data.cursor();
         let h_metrics_byte_len = number_of_h_metrics as usize * LongHorMetric::RAW_BYTE_LEN;

--- a/read-fonts/generated/generated_layout.rs
+++ b/read-fonts/generated/generated_layout.rs
@@ -23,9 +23,8 @@ impl ScriptListMarker {
     }
 }
 
-impl TableInfo for ScriptListMarker {
-    #[allow(unused_parens)]
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for ScriptList<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         let script_count: u16 = cursor.read()?;
         let script_records_byte_len = script_count as usize * ScriptRecord::RAW_BYTE_LEN;
@@ -153,9 +152,8 @@ impl ScriptMarker {
     }
 }
 
-impl TableInfo for ScriptMarker {
-    #[allow(unused_parens)]
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for Script<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         cursor.advance::<Offset16>();
         let lang_sys_count: u16 = cursor.read()?;
@@ -305,9 +303,8 @@ impl LangSysMarker {
     }
 }
 
-impl TableInfo for LangSysMarker {
-    #[allow(unused_parens)]
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for LangSys<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         cursor.advance::<u16>();
         cursor.advance::<u16>();
@@ -391,9 +388,8 @@ impl FeatureListMarker {
     }
 }
 
-impl TableInfo for FeatureListMarker {
-    #[allow(unused_parens)]
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for FeatureList<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         let feature_count: u16 = cursor.read()?;
         let feature_records_byte_len = feature_count as usize * FeatureRecord::RAW_BYTE_LEN;
@@ -524,16 +520,13 @@ impl FeatureMarker {
     }
 }
 
-impl ReadArgs for FeatureMarker {
+impl ReadArgs for Feature<'_> {
     type Args = Tag;
 }
 
-impl TableInfoWithArgs for FeatureMarker {
+impl<'a> FontReadWithArgs<'a> for Feature<'a> {
     #[allow(unused_parens)]
-    fn parse_with_args<'a>(
-        data: FontData<'a>,
-        args: &Tag,
-    ) -> Result<TableRef<'a, Self>, ReadError> {
+    fn read_with_args(data: FontData<'a>, args: &Tag) -> Result<Self, ReadError> {
         let feature_tag = *args;
         let mut cursor = data.cursor();
         cursor.advance::<Offset16>();
@@ -640,9 +633,8 @@ impl<T> Clone for LookupListMarker<T> {
 
 impl<T> Copy for LookupListMarker<T> {}
 
-impl<T> TableInfo for LookupListMarker<T> {
-    #[allow(unused_parens)]
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a, T> FontRead<'a> for LookupList<'a, T> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         let lookup_count: u16 = cursor.read()?;
         let lookup_offsets_byte_len = lookup_count as usize * Offset16::RAW_BYTE_LEN;
@@ -773,9 +765,8 @@ impl<T> Clone for LookupMarker<T> {
 
 impl<T> Copy for LookupMarker<T> {}
 
-impl<T> TableInfo for LookupMarker<T> {
-    #[allow(unused_parens)]
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a, T> FontRead<'a> for Lookup<'a, T> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         cursor.advance::<u16>();
         cursor.advance::<u16>();
@@ -916,9 +907,8 @@ impl CoverageFormat1Marker {
     }
 }
 
-impl TableInfo for CoverageFormat1Marker {
-    #[allow(unused_parens)]
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for CoverageFormat1<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         cursor.advance::<u16>();
         let glyph_count: u16 = cursor.read()?;
@@ -1001,9 +991,8 @@ impl CoverageFormat2Marker {
     }
 }
 
-impl TableInfo for CoverageFormat2Marker {
-    #[allow(unused_parens)]
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for CoverageFormat2<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         cursor.advance::<u16>();
         let range_count: u16 = cursor.read()?;
@@ -1194,9 +1183,8 @@ impl ClassDefFormat1Marker {
     }
 }
 
-impl TableInfo for ClassDefFormat1Marker {
-    #[allow(unused_parens)]
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for ClassDefFormat1<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         cursor.advance::<u16>();
         cursor.advance::<GlyphId>();
@@ -1287,9 +1275,8 @@ impl ClassDefFormat2Marker {
     }
 }
 
-impl TableInfo for ClassDefFormat2Marker {
-    #[allow(unused_parens)]
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for ClassDefFormat2<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         cursor.advance::<u16>();
         let class_range_count: u16 = cursor.read()?;
@@ -1520,9 +1507,8 @@ impl SequenceContextFormat1Marker {
     }
 }
 
-impl TableInfo for SequenceContextFormat1Marker {
-    #[allow(unused_parens)]
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for SequenceContextFormat1<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         cursor.advance::<u16>();
         cursor.advance::<Offset16>();
@@ -1639,9 +1625,8 @@ impl SequenceRuleSetMarker {
     }
 }
 
-impl TableInfo for SequenceRuleSetMarker {
-    #[allow(unused_parens)]
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for SequenceRuleSet<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         let seq_rule_count: u16 = cursor.read()?;
         let seq_rule_offsets_byte_len = seq_rule_count as usize * Offset16::RAW_BYTE_LEN;
@@ -1739,9 +1724,8 @@ impl SequenceRuleMarker {
     }
 }
 
-impl TableInfo for SequenceRuleMarker {
-    #[allow(unused_parens)]
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for SequenceRule<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         let glyph_count: u16 = cursor.read()?;
         let seq_lookup_count: u16 = cursor.read()?;
@@ -1850,9 +1834,8 @@ impl SequenceContextFormat2Marker {
     }
 }
 
-impl TableInfo for SequenceContextFormat2Marker {
-    #[allow(unused_parens)]
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for SequenceContextFormat2<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         cursor.advance::<u16>();
         cursor.advance::<Offset16>();
@@ -1991,9 +1974,8 @@ impl ClassSequenceRuleSetMarker {
     }
 }
 
-impl TableInfo for ClassSequenceRuleSetMarker {
-    #[allow(unused_parens)]
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for ClassSequenceRuleSet<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         let class_seq_rule_count: u16 = cursor.read()?;
         let class_seq_rule_offsets_byte_len =
@@ -2097,9 +2079,8 @@ impl ClassSequenceRuleMarker {
     }
 }
 
-impl TableInfo for ClassSequenceRuleMarker {
-    #[allow(unused_parens)]
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for ClassSequenceRule<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         let glyph_count: u16 = cursor.read()?;
         let seq_lookup_count: u16 = cursor.read()?;
@@ -2210,9 +2191,8 @@ impl SequenceContextFormat3Marker {
     }
 }
 
-impl TableInfo for SequenceContextFormat3Marker {
-    #[allow(unused_parens)]
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for SequenceContextFormat3<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         cursor.advance::<u16>();
         let glyph_count: u16 = cursor.read()?;
@@ -2393,9 +2373,8 @@ impl ChainedSequenceContextFormat1Marker {
     }
 }
 
-impl TableInfo for ChainedSequenceContextFormat1Marker {
-    #[allow(unused_parens)]
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for ChainedSequenceContextFormat1<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         cursor.advance::<u16>();
         cursor.advance::<Offset16>();
@@ -2516,9 +2495,8 @@ impl ChainedSequenceRuleSetMarker {
     }
 }
 
-impl TableInfo for ChainedSequenceRuleSetMarker {
-    #[allow(unused_parens)]
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for ChainedSequenceRuleSet<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         let chained_seq_rule_count: u16 = cursor.read()?;
         let chained_seq_rule_offsets_byte_len =
@@ -2640,9 +2618,8 @@ impl ChainedSequenceRuleMarker {
     }
 }
 
-impl TableInfo for ChainedSequenceRuleMarker {
-    #[allow(unused_parens)]
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for ChainedSequenceRule<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         let backtrack_glyph_count: u16 = cursor.read()?;
         let backtrack_sequence_byte_len = backtrack_glyph_count as usize * u16::RAW_BYTE_LEN;
@@ -2801,9 +2778,8 @@ impl ChainedSequenceContextFormat2Marker {
     }
 }
 
-impl TableInfo for ChainedSequenceContextFormat2Marker {
-    #[allow(unused_parens)]
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for ChainedSequenceContextFormat2<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         cursor.advance::<u16>();
         cursor.advance::<Offset16>();
@@ -2984,9 +2960,8 @@ impl ChainedClassSequenceRuleSetMarker {
     }
 }
 
-impl TableInfo for ChainedClassSequenceRuleSetMarker {
-    #[allow(unused_parens)]
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for ChainedClassSequenceRuleSet<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         let chained_class_seq_rule_count: u16 = cursor.read()?;
         let chained_class_seq_rule_offsets_byte_len =
@@ -3108,9 +3083,8 @@ impl ChainedClassSequenceRuleMarker {
     }
 }
 
-impl TableInfo for ChainedClassSequenceRuleMarker {
-    #[allow(unused_parens)]
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for ChainedClassSequenceRule<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         let backtrack_glyph_count: u16 = cursor.read()?;
         let backtrack_sequence_byte_len = backtrack_glyph_count as usize * u16::RAW_BYTE_LEN;
@@ -3281,9 +3255,8 @@ impl ChainedSequenceContextFormat3Marker {
     }
 }
 
-impl TableInfo for ChainedSequenceContextFormat3Marker {
-    #[allow(unused_parens)]
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for ChainedSequenceContextFormat3<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         cursor.advance::<u16>();
         let backtrack_glyph_count: u16 = cursor.read()?;
@@ -3600,9 +3573,8 @@ impl DeviceMarker {
     }
 }
 
-impl TableInfo for DeviceMarker {
-    #[allow(unused_parens)]
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for Device<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         let start_size: u16 = cursor.read()?;
         let end_size: u16 = cursor.read()?;
@@ -3688,8 +3660,8 @@ impl VariationIndexMarker {
     }
 }
 
-impl TableInfo for VariationIndexMarker {
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for VariationIndex<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         cursor.advance::<u16>();
         cursor.advance::<u16>();
@@ -3773,9 +3745,8 @@ impl FeatureVariationsMarker {
     }
 }
 
-impl TableInfo for FeatureVariationsMarker {
-    #[allow(unused_parens)]
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for FeatureVariations<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         cursor.advance::<MajorMinor>();
         let feature_variation_record_count: u32 = cursor.read()?;
@@ -3928,9 +3899,8 @@ impl ConditionSetMarker {
     }
 }
 
-impl TableInfo for ConditionSetMarker {
-    #[allow(unused_parens)]
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for ConditionSet<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         let condition_count: u16 = cursor.read()?;
         let condition_offsets_byte_len = condition_count as usize * Offset32::RAW_BYTE_LEN;
@@ -4029,8 +3999,8 @@ impl ConditionFormat1Marker {
     }
 }
 
-impl TableInfo for ConditionFormat1Marker {
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for ConditionFormat1<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         cursor.advance::<u16>();
         cursor.advance::<u16>();
@@ -4123,9 +4093,8 @@ impl FeatureTableSubstitutionMarker {
     }
 }
 
-impl TableInfo for FeatureTableSubstitutionMarker {
-    #[allow(unused_parens)]
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for FeatureTableSubstitution<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         cursor.advance::<MajorMinor>();
         let substitution_count: u16 = cursor.read()?;
@@ -4267,8 +4236,8 @@ impl SizeParamsMarker {
     }
 }
 
-impl TableInfo for SizeParamsMarker {
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for SizeParams<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         cursor.advance::<u16>();
         cursor.advance::<u16>();
@@ -4372,8 +4341,8 @@ impl StylisticSetParamsMarker {
     }
 }
 
-impl TableInfo for StylisticSetParamsMarker {
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for StylisticSetParams<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         cursor.advance::<u16>();
         cursor.advance::<u16>();
@@ -4471,9 +4440,8 @@ impl CharacterVariantParamsMarker {
     }
 }
 
-impl TableInfo for CharacterVariantParamsMarker {
-    #[allow(unused_parens)]
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for CharacterVariantParams<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         cursor.advance::<u16>();
         cursor.advance::<u16>();

--- a/read-fonts/generated/generated_maxp.rs
+++ b/read-fonts/generated/generated_maxp.rs
@@ -87,8 +87,8 @@ impl MaxpMarker {
     }
 }
 
-impl TableInfo for MaxpMarker {
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for Maxp<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         let version: Version16Dot16 = cursor.read()?;
         cursor.advance::<u16>();

--- a/read-fonts/generated/generated_name.rs
+++ b/read-fonts/generated/generated_name.rs
@@ -42,9 +42,8 @@ impl NameMarker {
     }
 }
 
-impl TableInfo for NameMarker {
-    #[allow(unused_parens)]
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for Name<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         let version: u16 = cursor.read()?;
         let count: u16 = cursor.read()?;

--- a/read-fonts/generated/generated_post.rs
+++ b/read-fonts/generated/generated_post.rs
@@ -67,9 +67,8 @@ impl PostMarker {
     }
 }
 
-impl TableInfo for PostMarker {
-    #[allow(unused_parens)]
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for Post<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         let version: Version16Dot16 = cursor.read()?;
         cursor.advance::<Fixed>();

--- a/read-fonts/generated/generated_test.rs
+++ b/read-fonts/generated/generated_test.rs
@@ -35,8 +35,8 @@ impl KindsOfOffsetsMarker {
     }
 }
 
-impl TableInfo for KindsOfOffsetsMarker {
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for KindsOfOffsets<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         let version: MajorMinor = cursor.read()?;
         cursor.advance::<Offset16>();
@@ -201,9 +201,8 @@ impl KindsOfArraysOfOffsetsMarker {
     }
 }
 
-impl TableInfo for KindsOfArraysOfOffsetsMarker {
-    #[allow(unused_parens)]
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for KindsOfArraysOfOffsets<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         let version: MajorMinor = cursor.read()?;
         let count: u16 = cursor.read()?;
@@ -405,8 +404,8 @@ impl DummyMarker {
     }
 }
 
-impl TableInfo for DummyMarker {
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError> {
+impl<'a> FontRead<'a> for Dummy<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         cursor.advance::<u16>();
         cursor.finish(DummyMarker {})

--- a/read-fonts/src/lib.rs
+++ b/read-fonts/src/lib.rs
@@ -44,7 +44,7 @@ pub(crate) mod codegen_prelude {
     pub use crate::font_data::{Cursor, FontData};
     pub use crate::offset::{Offset, ResolveNullableOffset, ResolveOffset};
     pub use crate::read::{ComputeSize, FontRead, FontReadWithArgs, Format, ReadArgs, ReadError};
-    pub use crate::table_ref::{TableInfo, TableInfoWithArgs, TableRef};
+    pub use crate::table_ref::TableRef;
     pub use font_types::*;
     pub use std::ops::Range;
 

--- a/read-fonts/src/table_ref.rs
+++ b/read-fonts/src/table_ref.rs
@@ -4,38 +4,12 @@ use super::read::{FontRead, Format, ReadError};
 use crate::{
     font_data::FontData,
     offset::{Offset, ResolveOffset},
-    read::{FontReadWithArgs, ReadArgs},
 };
 
 /// Typed access to raw table data.
 pub struct TableRef<'a, T> {
     pub(crate) shape: T,
     pub(crate) data: FontData<'a>,
-}
-
-/// A trait for types that describe the structure of a specific font table.
-///
-/// Instances of this type are constructed from the *specific* data of a particular
-/// instance of a given table, and the successful construction of the type acts
-/// as a validation of the input data.
-///
-/// In particular, the info type records the lengths of variable length fields,
-/// the existence of version-dependent fields, and anything else that varies
-/// between instances of a given table.
-///
-/// These stored values can be used at runtime to provide fast access to a table's
-/// fields, without needing to perform redundant bounds checks.
-pub trait TableInfo: Sized + Copy {
-    fn parse(data: FontData) -> Result<TableRef<Self>, ReadError>;
-}
-
-/// A trait for types that describe the structure of a font table, but require
-/// additional information.
-pub trait TableInfoWithArgs: Sized + Copy + ReadArgs {
-    fn parse_with_args<'a>(
-        data: FontData<'a>,
-        args: &Self::Args,
-    ) -> Result<TableRef<'a, Self>, ReadError>;
 }
 
 impl<'a, T> TableRef<'a, T> {
@@ -53,23 +27,6 @@ impl<'a, T> TableRef<'a, T> {
 }
 
 // a blanket impl so that the format is available through a TableRef
-impl<U, T: TableInfo + Format<U>> Format<U> for TableRef<'_, T> {
+impl<U, T: Format<U>> Format<U> for TableRef<'_, T> {
     const FORMAT: U = T::FORMAT;
-}
-
-// blanket impl of FontRead for any TableRef
-impl<'a, T: TableInfo> FontRead<'a> for TableRef<'a, T> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        T::parse(data)
-    }
-}
-
-impl<'a, T: ReadArgs> ReadArgs for TableRef<'a, T> {
-    type Args = T::Args;
-}
-
-impl<'a, T: TableInfoWithArgs> FontReadWithArgs<'a> for TableRef<'a, T> {
-    fn read_with_args(data: FontData<'a>, args: &Self::Args) -> Result<Self, ReadError> {
-        T::parse_with_args(data, args)
-    }
 }


### PR DESCRIPTION
I realized we can just implement FontRead/FontReadWithArgs directly, which is easier to understand and lets us remove these traits completly from the API.