### PR TITLE
[codegen] Remove generated #[ignore(unused_parens)]

### DIFF
--- a/font-codegen/src/table.rs
+++ b/font-codegen/src/table.rs
@@ -118,14 +118,6 @@ fn generate_font_read(item: &Table) -> syn::Result<TokenStream> {
         );)
     });
 
-    // add this attribute if we're going to be generating expressions which
-    // may trigger a warning
-    let ignore_parens = item
-        .fields
-        .iter()
-        .any(|fld| fld.has_computed_len())
-        .then(|| quote!(#[allow(unused_parens)]));
-
     // the cursor doesn't need to be mut if there are no fields,
     // which happens at least once (in glyf)?
     let maybe_mut_kw = (!item.fields.fields.is_empty()).then(|| quote!(mut));
@@ -140,7 +132,6 @@ fn generate_font_read(item: &Table) -> syn::Result<TokenStream> {
             }
 
             impl<'a> FontReadWithArgs<'a> for #name<'a> {
-                #ignore_parens
                 fn read_with_args(data: FontData<'a>, args: &#args_type) -> Result<Self, ReadError> {
                     let #destructure_pattern = *args;
                     let #maybe_mut_kw cursor = data.cursor();
@@ -154,7 +145,6 @@ fn generate_font_read(item: &Table) -> syn::Result<TokenStream> {
     } else {
         Ok(quote! {
             impl<'a, #generic> FontRead<'a> for #name<'a, #generic> {
-            #ignore_parens
             fn read(data: FontData<'a>) -> Result<Self, ReadError> {
                 let #maybe_mut_kw cursor = data.cursor();
                 #( #field_validation_stmts )*

--- a/read-fonts/generated/generated_gpos.rs
+++ b/read-fonts/generated/generated_gpos.rs
@@ -1206,7 +1206,6 @@ impl ReadArgs for PairSet<'_> {
 }
 
 impl<'a> FontReadWithArgs<'a> for PairSet<'a> {
-    #[allow(unused_parens)]
     fn read_with_args(
         data: FontData<'a>,
         args: &(ValueFormat, ValueFormat),
@@ -2053,7 +2052,6 @@ impl ReadArgs for BaseArray<'_> {
 }
 
 impl<'a> FontReadWithArgs<'a> for BaseArray<'a> {
-    #[allow(unused_parens)]
     fn read_with_args(data: FontData<'a>, args: &u16) -> Result<Self, ReadError> {
         let mark_class_count = *args;
         let mut cursor = data.cursor();
@@ -2375,7 +2373,6 @@ impl ReadArgs for LigatureArray<'_> {
 }
 
 impl<'a> FontReadWithArgs<'a> for LigatureArray<'a> {
-    #[allow(unused_parens)]
     fn read_with_args(data: FontData<'a>, args: &u16) -> Result<Self, ReadError> {
         let mark_class_count = *args;
         let mut cursor = data.cursor();
@@ -2482,7 +2479,6 @@ impl ReadArgs for LigatureAttach<'_> {
 }
 
 impl<'a> FontReadWithArgs<'a> for LigatureAttach<'a> {
-    #[allow(unused_parens)]
     fn read_with_args(data: FontData<'a>, args: &u16) -> Result<Self, ReadError> {
         let mark_class_count = *args;
         let mut cursor = data.cursor();
@@ -2804,7 +2800,6 @@ impl ReadArgs for Mark2Array<'_> {
 }
 
 impl<'a> FontReadWithArgs<'a> for Mark2Array<'a> {
-    #[allow(unused_parens)]
     fn read_with_args(data: FontData<'a>, args: &u16) -> Result<Self, ReadError> {
         let mark_class_count = *args;
         let mut cursor = data.cursor();

--- a/read-fonts/generated/generated_hmtx.rs
+++ b/read-fonts/generated/generated_hmtx.rs
@@ -29,7 +29,6 @@ impl ReadArgs for Hmtx<'_> {
 }
 
 impl<'a> FontReadWithArgs<'a> for Hmtx<'a> {
-    #[allow(unused_parens)]
     fn read_with_args(data: FontData<'a>, args: &(u16, u16)) -> Result<Self, ReadError> {
         let (number_of_h_metrics, num_glyphs) = *args;
         let mut cursor = data.cursor();

--- a/read-fonts/generated/generated_layout.rs
+++ b/read-fonts/generated/generated_layout.rs
@@ -525,7 +525,6 @@ impl ReadArgs for Feature<'_> {
 }
 
 impl<'a> FontReadWithArgs<'a> for Feature<'a> {
-    #[allow(unused_parens)]
     fn read_with_args(data: FontData<'a>, args: &Tag) -> Result<Self, ReadError> {
         let feature_tag = *args;
         let mut cursor = data.cursor();


### PR DESCRIPTION
At some point we changed the code we were generating such that this was no longer necessary.