### PR TITLE
[codegen] No repr(packed) for non-zerocopy records

### DIFF
--- a/read-fonts/generated/generated_gpos.rs
+++ b/read-fonts/generated/generated_gpos.rs
@@ -1282,8 +1282,6 @@ impl<'a> std::fmt::Debug for PairSet<'a> {
 
 /// Part of [PairSet]
 #[derive(Clone, Debug)]
-#[repr(C)]
-#[repr(packed)]
 pub struct PairValueRecord {
     /// Glyph ID of second glyph in the pair (first glyph is listed in
     /// the Coverage table).
@@ -1629,8 +1627,6 @@ impl<'a> SomeRecord<'a> for Class1Record<'a> {
 
 /// Part of [PairPosFormat2]
 #[derive(Clone, Debug)]
-#[repr(C)]
-#[repr(packed)]
 pub struct Class2Record {
     /// Positioning for first glyph — empty if valueFormat1 = 0.
     pub value_record1: ValueRecord,

--- a/read-fonts/src/font_data.rs
+++ b/read-fonts/src/font_data.rs
@@ -138,7 +138,7 @@ impl<'a> FontData<'a> {
     /// `T` must be a struct or scalar that has alignment of 1, a non-zero size,
     /// and no internal padding, and `range` must have a length that is non-zero
     /// and is a multiple of `size_of::<T>()`.
-    pub unsafe fn read_array_unchecked<T>(&self, range: Range<usize>) -> &'a [T] {
+    pub unsafe fn read_array_unchecked<T: FixedSized>(&self, range: Range<usize>) -> &'a [T] {
         let bytes = self.bytes.get_unchecked(range);
         let elems = bytes.len() / std::mem::size_of::<T>();
         std::slice::from_raw_parts(bytes.as_ptr() as *const _, elems)


### PR DESCRIPTION
The only rationale for adding these is to make the struct usable via transmute & co, and that is not something these types are doing. Having these annotations is potentially confusing, and also likely produces a sub-optimal memory layout.

This also updates the signature for FontData::read_array_unchecked to include a T: FixedSized bound; this omission was a bug.